### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,14 +8,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Publish Docker SemVer Tag
-      uses: elgohr/Publish-Docker-Github-Action@2.13
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: checkr/flagr
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         tag_semver: true
     - name: Publish Docker Latest Tag
-      uses: elgohr/Publish-Docker-Github-Action@2.13
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: checkr/flagr
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore